### PR TITLE
Add external config support

### DIFF
--- a/charts/compose-deployer/README.md
+++ b/charts/compose-deployer/README.md
@@ -33,9 +33,9 @@ The following chart outlines the supported elements from the Compose spec. Befor
 | `cap_add`, `cap_drop` | Yes | |
 | `cgroup_parent` | No | |
 | `command` | Yes | |
-| `configs` | Not yet | |
-| `configs: short-syntax` | Not yet | |
-| `configs: long-syntax` | Not yet | |
+| `configs` | Yes | Only external config supported, as Helm doesn't provide the ability to import non-templated files |
+| `configs: short-syntax` | Yes | |
+| `configs: long-syntax` | Yes | |
 | `container_name` | Yes | |
 | `credential_spec` | No | |
 | `depends_on` | No | |

--- a/charts/compose-deployer/templates/deployment.yaml
+++ b/charts/compose-deployer/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
               value: {{ $value }}
             {{- end }}
           {{- end }}
-          {{- if or .secrets .volumes }}
+          {{- if or (or .secrets .volumes) .configs }}
           volumeMounts:
             {{- if .secrets }}
             {{- range $secretData := .secrets }}
@@ -92,6 +92,17 @@ spec:
             {{- if .volumes }}
             {{- $volumeConfig := dict "containerVolumes" .volumes "volumeConfig" $.Values.volumes }}
             {{- include "volume_mounts" $volumeConfig | trim | nindent 12 -}}
+            {{- end }}
+            {{- if .configs }}
+            {{- range $configName := .configs }}
+            {{- if kindIs "string" $configName }}
+            - name: config-{{ $configName }}
+              mountPath: /{{ $configName }}
+            {{- else }}
+            - name: config-{{ $configName.source }}
+              mountPath: {{ default (printf "/%s" $configName.source) $configName.target }}
+            {{- end }}
+            {{- end }}
             {{- end }}
           {{- end }}
           {{- if $deploy.resources }}
@@ -148,7 +159,7 @@ spec:
             runAsUser: {{ .user }}
             {{- end }}
           {{- end }}
-      {{- if (or .secrets .volumes) }}
+      {{- if or (or .secrets .volumes) .configs }}
       volumes:
         {{- if .volumes }}
         {{- $volumeConfig := dict "containerVolumes" .volumes "volumeConfig" $.Values.volumes }}
@@ -164,6 +175,21 @@ spec:
         - name: secret-{{ $secretName }}
           secret:
             secretName: {{ $secretName }}
+        {{- end }}
+        {{- end }}
+        {{- if .configs }}
+        {{- range $config := .configs }}
+        {{- if kindIs "string" $config }}
+        {{- $configConfig := index $.Values.configs $config }}
+        - name: config-{{ $config }}
+          configMap: 
+            name: {{ default $config $configConfig.name }}
+        {{- else }}
+        {{- $configConfig := index $.Values.configs $config.source }}
+        - name: config-{{ $config.source }}
+          configMap:
+            name: {{ default $config.source $configConfig.name }}            
+        {{- end }}
         {{- end }}
         {{- end }}
       {{- end }}

--- a/charts/compose-deployer/tests/src/values/volumes.yaml
+++ b/charts/compose-deployer/tests/src/values/volumes.yaml
@@ -6,6 +6,11 @@ services:
       - pvcdefault:/pvc-default
       - custom-name:/custom-name
       - /data:/host-data
+    configs:
+      - test
+      - overridden
+      - source: test2
+        target: /another-location
 
 volumes:
   pvcdefault:
@@ -15,3 +20,12 @@ volumes:
     driver_opts:
       storage_class: gp3
       size: 50Gi
+
+configs:
+  test:
+    external: true
+  test2:
+    external: true
+  overridden:
+    name: overridden-name
+    external: true

--- a/charts/compose-deployer/tests/src/volumes.spec.js
+++ b/charts/compose-deployer/tests/src/volumes.spec.js
@@ -102,3 +102,35 @@ describe("HostPath volume types", () => {
         expect(volumeMount.readOnly).toBe(true);
     });
 });
+
+describe("Externally-defined ConfigMap volumes", () => {
+    it("defines a basic ConfigMap volume correctly", () => {
+        const volume = deployment.spec.template.spec.volumes.find(v => v.name === "config-test");
+
+        expect(volume).toBeDefined();
+        expect(volume.configMap).toBeDefined();
+        expect(volume.configMap.name).toBe("test");
+    });
+
+    it("mounts a string-based configMap at /<map-name>", () => {
+        const volumeMount = deployment.spec.template.spec.containers[0].volumeMounts.find(v => v.name === "config-test");
+
+        expect(volumeMount).toBeDefined();
+        expect(volumeMount.mountPath).toBe("/test");
+    });
+
+    it("allows a config name to be overridden", () => {
+        const volume = deployment.spec.template.spec.volumes.find(v => v.name === "config-overridden");
+
+        expect(volume).toBeDefined();
+        expect(volume.configMap).toBeDefined();
+        expect(volume.configMap.name).toBe("overridden-name");
+    });
+
+    it("mounts the volume at the correct location when using long-syntax", () => {
+        const volumeMount = deployment.spec.template.spec.containers[0].volumeMounts.find(v => v.name === "config-test2");
+
+        expect(volumeMount).toBeDefined();
+        expect(volumeMount.mountPath).toBe("/another-location");
+    });
+});


### PR DESCRIPTION
Resolves #2, but with the modification that only external config is being supported. I tried a few different mechanisms to support ConfigMap creation using locally sourced files. But, Helm doesn't allow you to do that. The only files that can be imported are those that are bundled with the chart itself.